### PR TITLE
Add Barclamp Type to model (refactoring prep) [2/2]

### DIFF
--- a/crowbar_framework/app/models/test/barclamp_test.rb
+++ b/crowbar_framework/app/models/test/barclamp_test.rb
@@ -1,0 +1,19 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This class is the fall back class for barclamps that are missing Barclamp subclasses
+class Test::BarclampTest < Barclamp
+  
+end


### PR DESCRIPTION
We're subclassing barclamp as part of the work to pull apart the ServiceObject.

This pull introduces the type to the parent model.

Barclamps will now be able to add a NAMESPACED barclamp subclass with the following 
approach.

the file app/models/[barclampname]/barclamp_[barclampname].rb 
should contain the [BarclampNameSpace]::Barclamp[BarclampName] < Barclamp class.

For example, for the foo barclamp:
  file = app/models/foo/barclamp_foo.rm
  class = Foo::BarclampFoo < Barclamp

To prevent having to touch every barclamp, the current code implements a safety mechanism
where barclamps without the subclass will automatically get the BarclampFramework class.

I have added the new barclamp subclass (empty) for the Crowbar & Test barclamps.

This pull also contains some minor doc updates and BDD test cleanup.

 crowbar_framework/app/models/test/barclamp_test.rb |   19 +++++++++++++++++++
 1 file changed, 19 insertions(+)

Crowbar-Pull-ID: 487fbfcd462d9d1e7ccdb337764bd0e3a8a23568

Crowbar-Release: development
