### PR TITLE
Allow Images in Docs to render inline [2/2]

### DIFF
--- a/crowbar_framework/app/models/test/attrib_instance_test.rb
+++ b/crowbar_framework/app/models/test/attrib_instance_test.rb
@@ -1,0 +1,36 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Test::AttribInstanceTest < AttribInstance
+
+  # Returns state of value of :empty, :set (by API) or :managed (by Jig)
+  def state
+    :test
+  end   
+      
+  #def request=(value)
+  #end
+  
+  #def request
+  #end
+  
+  # used by the API when values are set outside of Jig runs
+  #def actual=(value)
+  #end
+  
+  #def actual
+  #end
+    
+end


### PR DESCRIPTION
This small change allows documentation writers to include images
in their doc pages simply by using the  syntax.

This doc practice is documented in the formatting.md page that is
already committed.

I also moved the docs to be a child of the devguide rather than UI
information.

 .../app/models/test/attrib_instance_test.rb        |   36 ++++++++++++++++++++
 1 file changed, 36 insertions(+)

Crowbar-Pull-ID: f9b1f81ad8f45c03928d7b816b2879b540b01057

Crowbar-Release: development
