### PR TITLE
Refactor NodeAttrib to be AttribInstance instead [2/2]

### DIFF
--- a/crowbar_framework/app/models/test/attrib_instance_test.rb
+++ b/crowbar_framework/app/models/test/attrib_instance_test.rb
@@ -20,17 +20,23 @@ class Test::AttribInstanceTest < AttribInstance
     :test
   end   
       
-  #def request=(value)
-  #end
+ def request=(value)
+    self.jig_run_id = 0 if self.jig_run_id.nil?
+    self.value_request = AttribInstance.serial_in(value)
+  end
   
-  #def request
-  #end
+  def request
+    AttribInstance.serial_out value_request
+  end
   
   # used by the API when values are set outside of Jig runs
-  #def actual=(value)
-  #end
+  def actual=(value)
+    self.jig_run_id = 0 if self.jig_run_id.nil?
+    self.value_actual = AttribInstance.serial_in(value)
+  end
   
-  #def actual
-  #end
+  def actual
+    "test:"+AttribInstance.serial_out(value_actual)
+  end
     
 end

--- a/crowbar_framework/test/unit/attrib_instance_test_model_test.rb
+++ b/crowbar_framework/test/unit/attrib_instance_test_model_test.rb
@@ -1,0 +1,52 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+require 'test_helper'
+require 'json'
+
+class AttribInstanceTestModelTest < ActiveSupport::TestCase
+
+  # tests the relationship between nodes and attributes
+  def setup
+    # setup node w/ attribute
+    @value = "unit test"
+    @crowbar = Barclamp.find_or_create_by_name :name=>"test"
+    @node = Node.find_or_create_by_name :name=>"units.test.com"
+    @attrib = Attrib.find_or_create_by_name :name=>"barclamp_subclass_test"
+    @na = @node.attrib_set @attrib, @value, nil, Test::AttribInstanceTest
+    assert_not_nil @na
+    assert_equal "test:"+@value, @na.value
+    # Ruby 1.8 and 1.9 throws different exceptions in this case, so handle it
+    # accordingly. Simplify once we remove 1.8 support.
+    @error_class = (RUBY_VERSION == '1.8.7') ? NameError : ArgumentError
+  end
+
+  test "make sure that we can subclass AttribInstance in barclamps" do
+    a = Attrib.create :name=>"got_class"
+    assert_not_nil a
+    ai = Test::AttribInstanceTest.create :attrib_id=>a.id, :node_id => @node.id
+    assert_not_nil ai
+    assert_instance_of Test::AttribInstanceTest, ai
+    assert_equal "got_class", ai.attrib.name
+  end
+
+  test "make sure that we can node attrib_set takes subclass" do
+    na = @node.attrib_set "subclass_me", "override", nil, Test::AttribInstanceTest
+    assert_instance_of Test::AttribInstanceTest, na
+    assert_equal "test:override", na.value
+    assert_equal "subclass_me", na.attrib.name
+    assert_equal :test, na.state    
+  end
+
+end


### PR DESCRIPTION
 .../app/models/test/attrib_instance_test.rb        |   22 ++++++---
 .../test/unit/attrib_instance_test_model_test.rb   |   52 ++++++++++++++++++++
 2 files changed, 66 insertions(+), 8 deletions(-)

Crowbar-Pull-ID: 25328af38f2732f1a16376365b19fb775ffc745f

Crowbar-Release: development
