### PR TITLE
Update Barclamp namespace to match pattern for post-Engines [2/2]

### DIFF
--- a/crowbar_framework/app/models/test/barclamp.rb
+++ b/crowbar_framework/app/models/test/barclamp.rb
@@ -14,6 +14,6 @@
 #
 
 # This class is the fall back class for barclamps that are missing Barclamp subclasses
-class Test::BarclampTest < Barclamp
+class Test::Barclamp < Barclamp
   
 end


### PR DESCRIPTION
This small change reflects the coming changes for the engines refactoring.

Basically, we are trying to not repeat the barclamp name if it is already
included in the namespace.

The key change here is to allow the Barclamp model to automatically use 
the correct barclamp models when they are created and have a fallback
option if they are not.

Eventually, the fallback could be removed.

NOTE: Also fixed deprication warnings in BDD.

 crowbar_framework/app/models/test/barclamp.rb      |   19 +++++++++++++++++++
 crowbar_framework/app/models/test/barclamp_test.rb |   19 -------------------
 2 files changed, 19 insertions(+), 19 deletions(-)

Crowbar-Pull-ID: 6d4d45007b2fdd505a113d7442908e03d9c00241

Crowbar-Release: development
