### PR TITLE
change uses of throw to raise

### DIFF
--- a/crowbar_framework/test/unit/attrib_test_model_test.rb
+++ b/crowbar_framework/test/unit/attrib_test_model_test.rb
@@ -28,7 +28,7 @@ class AttribTestModelTest < ActiveSupport::TestCase
     assert_not_nil @na
     assert_instance_of BarclampTest::AttribTest, @na
     assert_equal "test:"+@value, @na.value
-    # Ruby 1.8 and 1.9 throws different exceptions in this case, so handle it
+    # Ruby 1.8 and 1.9 raise different exceptions in this case, so handle it
     # accordingly. Simplify once we remove 1.8 support.
     @error_class = (RUBY_VERSION == '1.8.7') ? NameError : ArgumentError
   end


### PR DESCRIPTION
'throw' is for escaping from control flow, whereas 'raise' is for
error conditions, e.g.

http://rubylearning.com/blog/2011/07/12/throw-catch-raise-rescue-im-so-confused/
