### PR TITLE
Next round of essex-hack-suse forward ports [2/2]

### DIFF
--- a/bin/barclamp_test.rb
+++ b/bin/barclamp_test.rb
@@ -107,7 +107,7 @@ def api_tests
   assertEqual(post_json("/proposals/test_p1", response[0].to_json), ["{}", 200], "Failed to edit test_p1", "Success: editting test_p1")
   
   response[0][:fred] = "bad"
-  assertEqual(post_json("/proposals/test_p1", response[0].to_json), ["key 'fred:' is undefined.\n", 400], "Failed to fail editting test_p1", "Success: failed to edit test_p1")
+  assertEqual(post_json("/proposals/test_p1", response[0].to_json), ["Failed to validate proposal: key 'fred:' is undefined.\n", 400], "Failed to fail editting test_p1", "Success: failed to edit test_p1")
 
   assertEqual(delete_json("/proposals/test_p1"), ["{}", 200], "Failed to API delete proposal: test_p1", "Success: delete test_p1 proposal")
   assertEqual(delete_json("/proposals/test_p1"), ["Error, could not delete proposal.", 404], "Failed to API delete proposal: missing test_p1", "Success: not finding to delete test_p1 proposal")


### PR DESCRIPTION
This contains the next chunk of our essex-hack-suse work. As previously
cherry-picked from
https://github.com/SUSE-Cloud/barclamp-crowbar/commits/release/essex-hack-suse/master

Where appropriat I squashed multiple commits together to make the patchset
smaller and cleaner.

 bin/barclamp_test.rb | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 137ce7e8cd78cc0ffe2196fc1c693585dff02813

Crowbar-Release: pebbles
