### PR TITLE
Annealer cycle runs from UI [2/2]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
@@ -24,7 +24,8 @@ class BarclampTest::Jig < Jig
     raise "Cannot call TestJig::Run on #{nr.name}" unless nr.state == NodeRole::TRANSITION
     # Hardcode this for now
     begin
-      %x["touch /tmp/test-jig-node-role-#{node.name}"]
+      puts "ZEHICLE test jig running #{nr.inspect}"
+      %x[touch /tmp/test-jig-node-role-#{nr.node.name}]
       nr.state = NodeRole::ACTIVE
     rescue
       nr.state = NodeRole::ERROR
@@ -32,12 +33,14 @@ class BarclampTest::Jig < Jig
   end
 
   def create_node(node)
-    %x["touch /tmp/test-jig-node-#{node.name}"]
+    puts "ZEHICLE test jig create #{node.inspect}"
+    %x[touch /tmp/test-jig-node-#{node.name}]
     Rails.logger.info("TestJig Creating node: #{node.name}")
   end
 
   def delete_node(node)
-    %x["rm /tmp/test-jig-node-#{node.name}"]
+    puts "ZEHICLE test jig delete #{node.inspect}"
+    %x[rm /tmp/test-jig-node-#{node.name}]
     Rails.logger.info("TestJig Deleting node: #{node.name}")    
   end
   


### PR DESCRIPTION
This pull fixes a few bugs that were blocking the annealer from running
1) %x incorrect for test barclamp
2) not deleting nodes correctly
3) added cycle method for snapshot

There are currently TWO paths for the annealer > node_role and snapshot.  
We should resolve this shortly.  For now, the real action is not in that code.

My testing includes creating nodes using the erlang simulator: dev:pop()

This command (in erlang) will setup a 5 node system with the default roles.

To run the annealer,
1) go to your deployment and select the committed snapshot
2) click the "to do actions" button
3) that puts one node-role into transistioning
4) click back to snapshot to admire the grid UI
5) go back to "to do actions"
6) click "run cycle" to execute the annealer (the first action Script jig and slow)
7) repeat and profit

We have not yet added code that transitions the snapshot to active when all 
node-roles are ready.  That is next.

 .../barclamp_test/app/models/barclamp_test/jig.rb  |    9 ++++++---
 1 file changed, 6 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 1a38f4d27d34d3bee8783ac800982da3e56dbadc

Crowbar-Release: development
