### PR TITLE
When all node-roles are active, make the snapshot active [2/2]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
@@ -24,8 +24,8 @@ class BarclampTest::Jig < Jig
     raise "Cannot call TestJig::Run on #{nr.name}" unless nr.state == NodeRole::TRANSITION
     # Hardcode this for now
     begin
-      puts "ZEHICLE test jig running #{nr.inspect}"
-      %x[touch /tmp/test-jig-node-role-#{nr.node.name}]
+      Rails.logger.info("TestJig Running node-role: #{nr.to_s}")    
+      %x[touch /tmp/test-jig-node-role-#{nr.to_s}]
       nr.state = NodeRole::ACTIVE
     rescue
       nr.state = NodeRole::ERROR
@@ -33,13 +33,11 @@ class BarclampTest::Jig < Jig
   end
 
   def create_node(node)
-    puts "ZEHICLE test jig create #{node.inspect}"
     %x[touch /tmp/test-jig-node-#{node.name}]
     Rails.logger.info("TestJig Creating node: #{node.name}")
   end
 
   def delete_node(node)
-    puts "ZEHICLE test jig delete #{node.inspect}"
     %x[rm /tmp/test-jig-node-#{node.name}]
     Rails.logger.info("TestJig Deleting node: #{node.name}")    
   end


### PR DESCRIPTION
This pull is the last yard, when you set a node-role to active
it will check to see if all the other node-roles in the snapshot are active.

If so, it will activate the snapshot.

 .../barclamp_test/app/models/barclamp_test/jig.rb  |    6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 297efb9d2eccac3982d6e3a1f8c7ea7fe0d4ec68

Crowbar-Release: development
