### PR TITLE
Advancing annealer function: now you can drop nodes into roles to create node-roles [2/2]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
@@ -28,7 +28,7 @@ class BarclampTest::Jig < Jig
       if data["test"] || true
         Rails.logger.info("TestJig Running node-role: #{nr.to_s}")    
         %x[touch /tmp/test-jig-node-role-test-#{data["marker"] || nr.name}.txt]
-        puts "TEST JIG >> Working #(nr.node.name} #{data["marker"]} & pausing for #{data["delay"]}"
+        puts "TEST JIG >> Working #{nr.node.name} #{data["marker"]} & pausing for #{data["delay"]}"
         sleep data["delay"] || 0
       end
       nr.state = NodeRole::ACTIVE


### PR DESCRIPTION
This brings together several aspects of work around deployment_role and node role

The most significant aspect of this pull is from the deployment screen: 
- you can now view the nodes and roles assigned to a deployment. 
- you can add deployment roles to a deployment (based on which are available)
- you can drop nodes into deployment roles to create a node_role
- you can run the whole things and watch the annear work (you can see it think!)

Some interesting aspects of the deployment state:
- if you add a node-role to an active deployment, it will create a proposal node-role
- if you add a node-role to a committed deployement, it will create a todo node-role
  in this case, the annealer will pickup the node-role and run it!

Other benefits - to enable BDD of node_role, I had to allow you to create node roles
using the name of the snapshot, role and node.

Also: run annealer from the UI is now set to run in the background.  There's a tax for this,
it takes several seconds for the background thread to spin up.  It's not a long term
thing, it's just for development.  Eventually, I expect to use delayed job for this.

 .../barclamp_test/app/models/barclamp_test/jig.rb  |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 5c24290fb705881acd4bb488abbee2aaeb37b833

Crowbar-Release: development
