### PR TITLE
Expose attrib setting API for testing, expose attribs in node UI [2/2]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/attrib.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/attrib.rb
@@ -19,11 +19,24 @@ class BarclampTest::Attrib < Attrib
 
     case self.map
     when 'random'
-      data[:test][:random]
+      data['test']['random'].to_i
     when 'marker'
-      data[:test][:marker]
+      data['test']['marker']
     else
-      nil
+      raise 'unknown map'
+    end
+
+  end
+
+  def discovery(data)
+
+    case self.map
+    when 'random'
+      { 'test'=> {'random'=>data}}
+    when 'marker'
+      { 'test'=> {'marker'=>data}}
+    else
+      raise 'unknown map'
     end
 
   end

--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
@@ -36,7 +36,7 @@ class BarclampTest::Jig < Jig
           Rails.logger.info("TestJig Running node-role: #{nr.to_s}")    
           %x[touch /tmp/test-jig-node-role-test-#{data["marker"] || nr.name}.txt]
           puts "TEST JIG >> Working #{nr.node.name} #{data["marker"]} & pausing for #{data["delay"]}"
-          sleep data["delay"] || 0
+          sleep data["delay"].to_i || 0
         end
         nr.state = NodeRole::ACTIVE
       rescue Exception => e


### PR DESCRIPTION
Exposes ways to set node.discovery attributes in order to allow round trip testing
of the attribute system.

It made sense to have the attrib model be able to create a discovery mapping to make it
easy and consistent to set attributes on nodes.

The API allows directly injecting discovery json to the node model OR
  just setting the attribute using /nodes/[]/attribs/[] {value:setme}

The docs and tests have been updated with this functionality.

Additional bugs fixed in this pull
- application controller was not updating attributes correctly
- test jig was failing when delay was set as a string
  
  .../app/models/barclamp_test/attrib.rb             |   19 ++++++++++++++++---
  .../barclamp_test/app/models/barclamp_test/jig.rb  |    2 +-
  2 files changed, 17 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 1e1d51f3a00255be609e66e7e29427b97c63f986

Crowbar-Release: development
