### PR TITLE
Add barclamp::role override for roles without specific class overrides (with TESTS) [2/2]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/role.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/role.rb
@@ -13,7 +13,7 @@
 # limitations under the License. 
 # 
 
-class BarclampTest::Library < Role
+class BarclampTest::Role < Role
 
 end
 


### PR DESCRIPTION
This change supports barclamps (like Network) that need to add roles dynamically but still 
need to override the default Crowbar Role behavior.

When a Role is created, Crowbar will look for a matching BarclampName::RoleName class.  If this
specific override is not found, then Crowbar will look for BarclampName::Role class.  If that 
general override is not found, Crowbar will use its own Role model.  

Overrides are needed to allow event customization.

This pull request includes BOTH tests specific to this behavior AND documentation of the behavior.

Yes, we are raising the bar.  You will comply.

 .../app/models/barclamp_test/library.rb            |   19 -------------------
 .../barclamp_test/app/models/barclamp_test/role.rb |   19 +++++++++++++++++++
 2 files changed, 19 insertions(+), 19 deletions(-)

Crowbar-Pull-ID: 01b3ea25901a0e494377a180af1bb08f0f02caef

Crowbar-Release: development
