### PR TITLE
Graph NodeRole relationships (initial views) [2/2]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
@@ -34,13 +34,15 @@ class BarclampTest::Jig < Jig
         # running the actions from the node role
         Rails.logger.info("TestJig Running node-role: #{nr.to_s}")    
         %x[touch /tmp/test-jig-node-role-test-#{data["marker"] || nr.name}.txt]
-        puts "TEST JIG >> Working #{nr.node.name} #{data["marker"]} & pausing for #{data["delay"]}"
-        Rails.logger.info "TEST JIG >> Working #{nr.node.name} #{data["marker"]} & pausing for #{data["delay"]}"
+        o = "TEST JIG >> Working #{nr.node.name} #{data["marker"]} & pausing for #{data["delay"]}"
+        puts o
+        Rails.logger.info o
+        nr.runlog = o
         # we want an easy way to turn off the delay setting
         if data["test"] || true or data["test"].eql? "true"
           sleep data["delay"].to_i || 0
         end
-        raise "test-fails role always fails" if nr.role.name.eql? 'test-fails'
+        raise "test-fails role always fails" if nr.role.  name.eql? 'test-fails'
         nr.state = NodeRole::ACTIVE
       rescue Exception => e
         nr.status = e.to_s


### PR DESCRIPTION
Using the InfoVis Toolkit (http://philogb.github.io/jit/static/v20/Jit/Examples/ForceDirected/example1.html),
I was able to create a graphical visualization for the NodeRole graph.

This is linked from the snapshot view (URI /snapshots/[ID]/graph).

The data is correctly rendered but some UI tweaking is needed to show the shapes and colors correctly.

This is a very handy way to help show to relationships between NodeRoles quickly. 

Visual enhancements should include showing the state, cohort and being able to drill-down from a vertex into the
node role data page.

Pull also include minor fixes to tests.

 .../barclamp_test/app/models/barclamp_test/jig.rb  |    8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: ec50262ec7fe8599260a9739fd3a8a7ac571c838

Crowbar-Release: development
