### PR TITLE
Network Barclamp UIs and Bootstrap Page UI and bunck of bugs/merges [3/3]

### DIFF
--- a/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-admin.html.haml
+++ b/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-admin.html.haml
@@ -1,3 +1,3 @@
 %p from the test-admin page
 
-= render :partial => 'raw', :locals => { :data => data, :node_role => node_role }
+= render :partial => 'node_roles/raw', :locals => { :data => data, :hide=>hide, :template => template }

--- a/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-client.html.haml
+++ b/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-client.html.haml
@@ -1,3 +1,4 @@
 %p from the test-client page
 
-= render :partial => 'raw', :locals => { :data => data, :node_role => node_role }
+= render :partial => 'node_roles/raw', :locals => { :data => data, :hide=>hide, :template => template }
+

--- a/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-library.html.haml
+++ b/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-library.html.haml
@@ -1,3 +1,3 @@
 %p from the test-library page
 
-= render :partial => 'raw', :locals => { :data => data, :node_role => node_role }
+= render :partial => 'node_roles/raw', :locals => { :data => data, :hide=>hide, :template => template }

--- a/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-server.html.haml
+++ b/crowbar_engine/barclamp_test/app/views/barclamp_test/node_roles/_test-server.html.haml
@@ -1,3 +1,3 @@
 %p from the test-server page
 
-= render :partial => 'raw', :locals => { :data => data, :node_role => node_role }
+= render :partial => 'node_roles/raw', :locals => { :data => data, :hide=>hide, :template => template }


### PR DESCRIPTION
This pull request got very large because the Bootstrap got very large because the concerns are interconnected.
# AREA 1: Networking UI

Add pages for Network configuration using the Network, Range and Router information
Add pages for Scaffolds
Fix issues related to building the UIs
Make the APIs follow patterns from the main part of Crowbar
Add BDD tests for Network
Add Role overlay screens (needed by Crowbar & bootstrap)
# AREA 2: Bootstrap UI

Add ability to create admin network
Add ability to view admin & server network roles
Fix bugs related to creating server and network
Improve how role overlays work
# AREA 3: Various Items

Fix bugs and docs
Handle merge conflicts (some commits where reversed later)

 .../barclamp_test/node_roles/_test-admin.html.haml |    2 +-
 .../node_roles/_test-client.html.haml              |    3 ++-
 .../node_roles/_test-library.html.haml             |    2 +-
 .../node_roles/_test-server.html.haml              |    2 +-
 4 files changed, 5 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: d1af870ffaea8f0e279951a579591a7bc94b371d

Crowbar-Release: development
