### PR TITLE
Bootstrap cleanup, fix tests broken by Jig changes, layercake exposed [5/5]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
@@ -20,13 +20,11 @@ require 'json'
 
 class BarclampTest::Jig < Jig
 
-  def run(nr)
+  def run(nr, data)
     raise "Cannot call TestJig::Run on #{nr.name}" unless nr.state == NodeRole::TRANSITION
 
     Node.transaction do
       begin
-        data = nr.data
-
         # create tests data
         disco = { :test=> { :random => Random.rand(1000000), :marker => data["marker"] }, data["marker"] => nr.id }
         nr.node.discovery = disco
@@ -50,6 +48,11 @@ class BarclampTest::Jig < Jig
       end
       nr.save!
     end
+  end
+
+  def stage_run(nr)
+    Rails.logger.info "BarclampTest::Jig.stage_run > '#{nr.role.name}' on '#{nr.node.name}'"
+    return nil
   end
 
   def create_node(node)


### PR DESCRIPTION
I pulled together a few streams in this pull so it got bigger than expected.
1. I had to make some small tweaks to the jig/run models because BDD was failing
   This included fixing the test jig to match the current pattern.
2. Fixed some strangeness with the bootstrap page where the page was reloading before
   the link was posted.  This should be much cleaner.  I also improved the wording
   to be less confusing based on feedback.  

2.5 Added overlay screens for the roles that are viewed during bootstrap so they
look cleaner.

WARNING: they overlay screens are READ ONLY - updating from them is a work in progress.
1. Updated the layercake (system overview) page to show only the active noderoles 
   using the scope we defined.  Also, improved the color maps and formatting for the
   boxes, titles and leds.

Note: There is a different pull with fixes for ./dev to support postgresql

KNOWN ISSUE: The test jig is throwing an error during annealing.  

 .../barclamp_test/app/models/barclamp_test/jig.rb  |    9 ++++++---
 1 file changed, 6 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: d8017cb3e43d33b986fe906b749188bff709ba7d

Crowbar-Release: development
