### PR TITLE
Fix Doc Index bug in production [2/2]

### DIFF
--- a/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
+++ b/crowbar_engine/barclamp_test/app/models/barclamp_test/jig.rb
@@ -52,7 +52,7 @@ class BarclampTest::Jig < Jig
 
   def stage_run(nr)
     Rails.logger.info "BarclampTest::Jig.stage_run > '#{nr.role.name}' on '#{nr.node.name}'"
-    return nil
+    return nr.all_my_data
   end
 
   def create_node(node)


### PR DESCRIPTION
Minor fix that was blocking the help index from being rendered in production mode.

 .../barclamp_test/app/models/barclamp_test/jig.rb  |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: d8cb572698b76f690f9024f11a53c5521a628a23

Crowbar-Release: development
